### PR TITLE
upgrade prettytable-rs

### DIFF
--- a/timed/Cargo.toml
+++ b/timed/Cargo.toml
@@ -13,4 +13,4 @@ timed_proc_macros = { version = "0.2.0" }
 # timed_proc_macros = { path = "../timed_proc_macros" }
 lazy_static = "1.4.0"
 thiserror = "1.0.21"
-prettytable-rs = "^0.8"
+prettytable-rs = "^0.10"


### PR DESCRIPTION
prettytable-rs 0.8.0 fails on rust 1.67 with segfault